### PR TITLE
Fix: Addition Operation failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -10,7 +10,7 @@ def result(request):
 
     
     if request.GET.get('add') == "":
-        ans = num1 * num2
+        ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
         ans = num1 - num2


### PR DESCRIPTION
Resolves #4

The addition operation is incorrectly implemented in the `result` view. The condition `if request.GET.get('add') == "":` currently executes multiplication (`num1 * num2`) instead of addition (`num1 + num2`).