### PR TITLE
Fix: Addition Failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -9,7 +9,7 @@ def result(request):
     num2 = int(request.GET.get('number2'))
 
     
-    if request.GET.get('add') == "":
+    if 'add' in request.GET:
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    


### PR DESCRIPTION
Resolves #3

The root cause is that the view logic explicitly checks if the 'add' parameter in the GET request is equal to an empty string (`== ""`). HTML submit buttons typically send their `value` attribute (e.g., 'Add', 'Sum', or similar) when clicked, or the browser might define default behavior. If the 'add' button sends any value other than an empty string, the condition fails, causing the logic to fall through to subsequent checks (eventually triggering the `else` block for division). The fix is to check for the *presence* of the 'add' key in the request parameters, rather than asserting its value is empty.