### PR TITLE
Fix: Addition Failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -9,13 +9,13 @@ def result(request):
     num2 = int(request.GET.get('number2'))
 
     
-    if request.GET.get('add') == "":
+    if 'add' in request.GET:
         ans = num1 + num2
 
-    elif request.GET.get('subtract') == "":    
+    elif 'subtract' in request.GET:    
         ans = num1 - num2
 
-    elif request.GET.get('multiply') == "":    
+    elif 'multiply' in request.GET:    
         ans = num1 * num2
 
     else:


### PR DESCRIPTION
Resolves #3

The code currently checks if the query parameters 'add', 'subtract', or 'multiply' are equal to an empty string (`== ""`) to determine the operation. However, HTML submit buttons typically send their value (e.g., the label text like 'Add') when clicked. If the button has a value other than an empty string, the condition `request.GET.get('add') == ""` evaluates to False, causing the logic to fall through to the `else` block (division). To fix this, the code should check for the *presence* of the specific key in `request.GET` rather than comparing its value to an empty string.