### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #8

The root cause is a logic error in `calculatorapp/views.py` within the `result` function. The condition checking for the 'subtract' operation (`elif request.GET.get('subtract') == "":`) incorrectly performs multiplication (`ans = num1 * num2`) instead of subtraction (`ans = num1 - num2`).