### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #8

The code in `calculatorapp/views.py` incorrectly performs multiplication (`*`) when the subtraction operation is requested. Specifically, inside the `elif request.GET.get('subtract') == "":` block, the calculation is `ans = num1 * num2` instead of `ans = num1 - num2`.