### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #8

The subtraction operation is failing because the code block intended for subtraction (`elif request.GET.get('subtract') == "":`) incorrectly performs multiplication (`ans = num1 * num2`) instead of subtraction (`ans = num1 - num2`).