### PR TITLE
Fix: Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #10

The root cause of the bug is a typographical error in the `result` function within `calculatorapp/views.py`. When the 'subtract' operation is detected, the code incorrectly performs multiplication (`ans = num1 * num2`) instead of the intended subtraction (`ans = num1 - num2`).