### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #8

The subtraction operation is failing because the code incorrectly performs multiplication (`num1 * num2`) when the 'subtract' parameter is detected. It should perform subtraction (`num1 - num2`).