### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2
@@ -22,3 +22,4 @@ def result(request):
         ans = num1 / num2
 
     return render(request,'result.html',{'ans': ans})
+    


### PR DESCRIPTION
Resolves #8

The subtraction operation is incorrectly implemented. Instead of performing `num1 - num2`, the code is performing `num1 * num2` when the 'subtract' button is clicked. This is causing the subtraction to fail and return an incorrect result.