### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #8

The issue is that the subtraction operation is not working correctly. In the `result` view, the code incorrectly uses multiplication (`ans = num1 * num2`) when the 'subtract' button is pressed, instead of performing subtraction.