### PR TITLE
Fix: Subtraction is failing

### DIFF
--- a/calculatorapp/views.py
+++ b/calculatorapp/views.py
@@ -13,7 +13,7 @@ def result(request):
         ans = num1 + num2
 
     elif request.GET.get('subtract') == "":    
-        ans = num1 * num2
+        ans = num1 - num2
 
     elif request.GET.get('multiply') == "":    
         ans = num1 * num2


### PR DESCRIPTION
Resolves #8

## Analysis
The subtraction operation in the calculator application is failing because the code mistakenly performs multiplication instead of subtraction. Specifically, on line 18 of `calculatorapp/views.py`, the line `ans = num1 * num2` should be corrected to `ans = num1 - num2` when the 'subtract' operation is detected.

## Steps
1. Open the file `calculatorapp/views.py`.
2. Locate the `result` function.
3. Find the `elif request.GET.get('subtract') == ":"` block.
4. Change the line `ans = num1 * num2` to `ans = num1 - num2` within this block.
5. Save the changes to `calculatorapp/views.py`.